### PR TITLE
prevent threading with unique subject lines

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,6 +24,7 @@ app.post('/', (req, res) => {
   const textversion = req.body.textversion;
   const htmlversion = req.body.htmlversion;
   const ampversion = req.body.ampversion;
+  const preventThreading = req.body.preventThreading;
 
   if ('MAIL_EMAIL' in process.env){ var email = process.env.MAIL_EMAIL }
   else { var email = req.body.email; }
@@ -53,11 +54,26 @@ app.post('/', (req, res) => {
     }
   });
 
+  function appendUniqueSubject(val) {
+    if(val == 'yes') {
+      let d = new Date();
+      let date = d.getUTCDate()
+      let month = d.getUTCMonth() + 1
+      let year = d.getUTCFullYear()
+      let hours = d.getUTCHours()
+      let mins = d.getUTCMinutes()
+      let secs = d.getUTCSeconds()
+      let dateStr = ` ${year}${month}${date} [${hours}:${mins}:${secs}]`
+      return dateStr
+    } else {
+      return ''
+    }
+  }
 
   let mailOptions = {
     from: `"${from}" <${email}>`,
     to: testaddress,
-    subject: testsubject,
+    subject: `${testsubject}${appendUniqueSubject(preventThreading)}`,
     html: htmlversion,
     text: textversion,
     amp: ampversion,

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -132,3 +132,10 @@ input:focus {
   grid-template-columns: auto auto;
   grid-gap: 1em;
 }
+.sender-extras label {
+  display:block;
+}
+.sender-extras input {
+  display: inline;
+  width: auto;
+}

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -90,6 +90,12 @@
                 <input type="text" id="setting-fontsize" class="setting-fontsize" name="fontsize" placeholder="ex: 1.3em">
               </label>
             </div>
+            <div class="sender-settings sender-extras">
+              <label for="setting-thread">
+                <input type="checkbox" id="setting-thread" class="setting-thread" name="preventThreading" value="yes">
+                  Prevent Threading         
+              </label>
+            </div>
           <button data-dismiss="modal">Close</button>
         </div>
       </div>


### PR DESCRIPTION
An option can now be enabled in the **settings** to append a unique string to the subject line. The string appended is a timestamp in the following format:
```
YYYYMMDD [HH:MM:SS]
```
If enabled, this will be automatically be added to the subject, upon each successful send. Also, if enabled, this will become the subject, if the subject field is intentionally left blank.