### PR TITLE
fix: update file name handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "can-i-send",
-  "version": "4.4.7",
+  "version": "4.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "can-i-send",
-      "version": "4.4.7",
+      "version": "4.4.8",
       "dependencies": {
         "@emotion/styled": "^11.14.0",
         "@monaco-editor/react": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "can-i-send",
   "private": true,
-  "version": "4.4.7",
+  "version": "4.4.8",
   "type": "module",
   "engines": {
     "node": "22.x",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "preview": "vite preview",
     "start": "npx nodemon app.js",
     "start-dev": "NODE_ENV=development npx nodemon app.js",
-    "tag": "git tag -a $npm_package_version -m \"Release version $npm_package_version\" && git push origin $npm_package_version"
+    "tag": "git tag -a $npm_package_version -m \"Release version $npm_package_version\" && git push origin $npm_package_version",
+    "patch": "npm version patch --no-git-tag-version"
   },
   "dependencies": {
     "@emotion/styled": "^11.14.0",

--- a/src/components/InputUpdateFiles.tsx
+++ b/src/components/InputUpdateFiles.tsx
@@ -18,10 +18,10 @@ const InputUpdateFiles = () => {
     if (!workingFileID || workingFileID === deletedWorkingFileID) {
       return
     }
+    setFileName(workingFileName)
     setOpen(true)
   }
 
-  // TODO: handle if text field is cleared and user clicks away
   const handleClose = () => {
     setOpen(false)
     setFileName('')
@@ -67,10 +67,9 @@ const InputUpdateFiles = () => {
             label={BTN_LABEL_UPDATE_DIALOG}
             type='text'
             fullWidth
-            value={fileName || workingFileName}
+            value={fileName}
             onChange={(e) => {
               setFileName(e.target.value)
-              setWorkingFileName(e.target.value)
             }}
             onKeyDown={(e) => {
               if (e.key === 'Enter') {


### PR DESCRIPTION
if a user clears the text field in the update dialog, and then cancels out of the dialog, the initial value will now display when the dialog is reopened. Previously, the value was cleared from state, and only retrievable via a broswer refresh.